### PR TITLE
build后自动开启express server，以支持开发完成后快速查看生产环境项目

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,8 +196,8 @@
 ***
 
 ## <a name="deployment">&sect; 部署</a>
-在 `react-demo` 的命令窗口下，敲下 `npm run build`，将会在项目根目录下生成 `dist/`  
-> 您可以使用命令行静态资源服务器 [serve](https://github.com/tj/serve) ( `npm i serve -g` )，敲下 `serve dist/ -p [端口]` 来快速查看 build 后的项目  
+在 `react-demo` 的命令窗口下，敲下 `npm run build`，将会在项目根目录下生成 `dist/` 同时开启一个express server，此时打开 `localhost:9091` 即可查看 build后的项目
+> 您也可以使用命令行静态资源服务器 [serve](https://github.com/tj/serve) ( `npm i serve -g` )，敲下 `serve dist/ -p [端口]` 来快速查看 build 后的项目  
 > 还可以 `cd dist` 后，`python -m SimpleHTTPServer [端口]` 或 `php -S localhost:[端口]` 快速便捷地实现静态资源服务器
 >
 > 关于生产环境下的部署与优化，已超出本文档的论述范围，请自行查阅相关资料  

--- a/build/prod.js
+++ b/build/prod.js
@@ -1,7 +1,10 @@
 var fs = require('fs'),
   path = require('path'),
   webpack = require('webpack'),
-  config = require('./webpack.prod.conf');
+  config = require('./webpack.prod.conf'),
+  express = require('express'),
+  port = process.env.PORT || 9091,
+  app = express();
 
 webpack(config, function(err, stats) {
   // show build info to console
@@ -12,4 +15,14 @@ webpack(config, function(err, stats) {
     path.join(config.commonPath.dist, '__build_info__'),
     stats.toString({ color: false })
   );
+
+  var rootPath = path.resolve(__dirname, '..')
+  // 通常用于加载静态资源
+  app.use(express.static(rootPath + '/dist'))
+  // 将所有路径指向index
+  app.get('*', function (request, response){
+    response.sendFile(rootPath + '/dist/index.html')
+  })
+  app.listen(port)
+  console.log("server started on port " + port)
 });


### PR DESCRIPTION
因为 TJ 的 serve 不支持无脑路由映射，所以查看生产环境项目的时候直接打开 http://localhost:9090/todo 会报 not found